### PR TITLE
Use toml-patch for comment and formatting preservation

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,13 +67,13 @@
     "vite": "^4.3.1"
   },
   "dependencies": {
+    "@decimalturn/toml-patch": "^0.4.1",
     "@floating-ui/dom": "^1.5.4",
     "clone": "^2.1.2",
     "fast-xml-parser": "^4.2.6",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "material-icons": "^1.13.8",
-    "smol-toml": "^1.3.0",
     "vite-plugin-css-injected-by-js": "^3.2.1",
     "xml-formatter": "^3.5.0",
     "zod": "^3.21.4"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "vite": "^4.3.1"
   },
   "dependencies": {
-    "@decimalturn/toml-patch": "^0.4.1",
+    "@decimalturn/toml-patch": "^0.5.0",
     "@floating-ui/dom": "^1.5.4",
     "clone": "^2.1.2",
     "fast-xml-parser": "^4.2.6",

--- a/src/guifier/classes/Data.ts
+++ b/src/guifier/classes/Data.ts
@@ -135,11 +135,19 @@ export class Data {
                 }
             case DataType.Toml:
                 try {
+                    // Strip time component from dates before serialization
+                    const processedData = lodash.cloneDeepWith(data, (value: any) => {
+                        if (value instanceof Date) {
+                            // Create a new date with time set to 00:00:00 UTC
+                            value = new Date(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate())
+                            return value
+                        }
+                    })
                     if (this.tomlDocument !== null) {
-                        this.tomlDocument.patch(data)
+                        this.tomlDocument.patch(processedData)
                         return this.tomlDocument.toTomlString
                     } else {
-                        return tomlStringify(data)
+                        return tomlStringify(processedData)
                     }
                 } catch (error: any) {
                     throw new Error(error)

--- a/src/guifier/classes/Data.ts
+++ b/src/guifier/classes/Data.ts
@@ -3,7 +3,7 @@ import clone from 'clone'
 import type { Property, Parameters } from '../types'
 
 import { XMLParser, XMLBuilder } from 'fast-xml-parser'
-import { TomlDate, parse as tomlParse, stringify as tomlStringify } from 'smol-toml'
+import { stringify as tomlStringify, TomlDocument } from '@decimalturn/toml-patch'
 import { defaultProperty } from '../types'
 import { DataType, PrimitiveTypes } from '../enums'
 import { getFieldTypeByValuetype, getType, mergeObjectsOnlyNewProperties } from '../utils'
@@ -19,6 +19,7 @@ export class Data {
     public parsedData: Property = defaultProperty
     public params: Parameters
     private readonly path: Array<number | string> = []
+    private tomlDocument: TomlDocument | null = null
 
     constructor (data: string, dataType: DataType, params: Parameters) {
         // add guifier params
@@ -87,7 +88,8 @@ export class Data {
                 }
             case DataType.Toml:
                 try {
-                    return tomlParse(data)
+                    this.tomlDocument = new TomlDocument(data)
+                    return this.tomlDocument.toJsObject
                 } catch (error: any) {
                     throw new Error(error)
                 }
@@ -133,13 +135,12 @@ export class Data {
                 }
             case DataType.Toml:
                 try {
-                    const processedData = lodash.cloneDeepWith(data, (value: any) => {
-                        if (value instanceof Date) {
-                            value = new TomlDate(value.toISOString().split('T')[0])
-                            return value
-                        }
-                    })
-                    return tomlStringify(processedData)
+                    if (this.tomlDocument !== null) {
+                        this.tomlDocument.patch(data)
+                        return this.tomlDocument.toTomlString
+                    } else {
+                        return tomlStringify(data)
+                    }
                 } catch (error: any) {
                     throw new Error(error)
                 }

--- a/src/guifier/classes/Data.ts
+++ b/src/guifier/classes/Data.ts
@@ -3,7 +3,7 @@ import clone from 'clone'
 import type { Property, Parameters } from '../types'
 
 import { XMLParser, XMLBuilder } from 'fast-xml-parser'
-import { stringify as tomlStringify, TomlDocument } from '@decimalturn/toml-patch'
+import { stringify as tomlStringify, TomlDocument, TomlFormat } from '@decimalturn/toml-patch'
 import { defaultProperty } from '../types'
 import { DataType, PrimitiveTypes } from '../enums'
 import { getFieldTypeByValuetype, getType, mergeObjectsOnlyNewProperties } from '../utils'
@@ -143,11 +143,17 @@ export class Data {
                             return value
                         }
                     })
+                    const format = TomlFormat.default()
+                    format.truncateZeroTimeInDates = true
                     if (this.tomlDocument !== null) {
-                        this.tomlDocument.patch(processedData)
+                        console.log('Patching existing TOML Document.')
+                        this.tomlDocument.patch(processedData, format)
                         return this.tomlDocument.toTomlString
                     } else {
-                        return tomlStringify(processedData)
+                        console.log("Resetting TOML Document as it wasn't initialized during parsing.")
+                        const tomlString = tomlStringify(processedData, format)
+                        this.tomlDocument = new TomlDocument(tomlString)
+                        return tomlString
                     }
                 } catch (error: any) {
                     throw new Error(error)

--- a/src/guifier/classes/Data.ts
+++ b/src/guifier/classes/Data.ts
@@ -144,7 +144,7 @@ export class Data {
                     const processedData = lodash.cloneDeepWith(data, (value: any) => {
                         if (value instanceof Date) {
                             // Create a new date with time set to 00:00:00 UTC
-                            value = new Date(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate())
+                            value = new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()))
                             return value
                         }
                     })

--- a/src/guifier/classes/Data.ts
+++ b/src/guifier/classes/Data.ts
@@ -88,7 +88,11 @@ export class Data {
                 }
             case DataType.Toml:
                 try {
+                    console.log('Setup TOML Document.')
                     this.tomlDocument = new TomlDocument(data)
+                    console.log('TOML Document setup complete:')
+                    console.log(this.tomlDocument.toTomlString)
+
                     return this.tomlDocument.toJsObject
                 } catch (error: any) {
                     throw new Error(error)
@@ -135,6 +139,7 @@ export class Data {
                 }
             case DataType.Toml:
                 try {
+                    console.log('Date received for TOML serialization:', data)
                     // Strip time component from dates before serialization
                     const processedData = lodash.cloneDeepWith(data, (value: any) => {
                         if (value instanceof Date) {
@@ -143,10 +148,12 @@ export class Data {
                             return value
                         }
                     })
+                    console.log('Processed data for TOML serialization:', processedData)
                     const format = TomlFormat.default()
                     format.truncateZeroTimeInDates = true
                     if (this.tomlDocument !== null) {
                         console.log('Patching existing TOML Document.')
+                        console.log(this.tomlDocument.toTomlString)
                         this.tomlDocument.patch(processedData, format)
                         return this.tomlDocument.toTomlString
                     } else {

--- a/src/guifier/classes/Data.ts
+++ b/src/guifier/classes/Data.ts
@@ -3,7 +3,7 @@ import clone from 'clone'
 import type { Property, Parameters } from '../types'
 
 import { XMLParser, XMLBuilder } from 'fast-xml-parser'
-import { stringify as tomlStringify, TomlDocument, TomlFormat } from '@decimalturn/toml-patch'
+import { TomlDocument, TomlFormat } from '@decimalturn/toml-patch'
 import { defaultProperty } from '../types'
 import { DataType, PrimitiveTypes } from '../enums'
 import { getFieldTypeByValuetype, getType, mergeObjectsOnlyNewProperties } from '../utils'
@@ -88,11 +88,7 @@ export class Data {
                 }
             case DataType.Toml:
                 try {
-                    console.log('Setup TOML Document.')
                     this.tomlDocument = new TomlDocument(data)
-                    console.log('TOML Document setup complete:')
-                    console.log(this.tomlDocument.toTomlString)
-
                     return this.tomlDocument.toJsObject
                 } catch (error: any) {
                     throw new Error(error)
@@ -139,29 +135,20 @@ export class Data {
                 }
             case DataType.Toml:
                 try {
-                    console.log('Date received for TOML serialization:', data)
+                    if (this.tomlDocument == null) {
+                        throw new Error('TOML Document not initialized.')
+                    }
                     // Strip time component from dates before serialization
                     const processedData = lodash.cloneDeepWith(data, (value: any) => {
                         if (value instanceof Date) {
-                            // Create a new date with time set to 00:00:00 UTC
                             value = new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()))
                             return value
                         }
                     })
-                    console.log('Processed data for TOML serialization:', processedData)
                     const format = TomlFormat.default()
                     format.truncateZeroTimeInDates = true
-                    if (this.tomlDocument !== null) {
-                        console.log('Patching existing TOML Document.')
-                        console.log(this.tomlDocument.toTomlString)
-                        this.tomlDocument.patch(processedData, format)
-                        return this.tomlDocument.toTomlString
-                    } else {
-                        console.log("Resetting TOML Document as it wasn't initialized during parsing.")
-                        const tomlString = tomlStringify(processedData, format)
-                        this.tomlDocument = new TomlDocument(tomlString)
-                        return tomlString
-                    }
+                    this.tomlDocument.patch(processedData, format)
+                    return this.tomlDocument.toTomlString
                 } catch (error: any) {
                     throw new Error(error)
                 }


### PR DESCRIPTION
This is a re-do of https://github.com/maliknajjar/guifier/pull/16, but for Guifier V2.

In order to support TOML formatting and comments, this PR replaced the `smol-toml` library with `@decimalturn/toml-patch` and made the necessary adjustments in the code. 

As discussed in https://github.com/maliknajjar/guifier/issues/19, the new approach makes use of the newly introduced TomlDocument object which allows to store the AST representation of the TOML document which includes the formatting. This way, we can use the `.patch()` method to update the document without losing the formatting.

Regarding dates, since Guifier doesn't support time components, I added a new formatting option (`truncateZeroTimeInDates`) to remove the excess `T00:00:00.000Z` that would be added to the TOML document when a date was added via the UI.